### PR TITLE
Add lsm4/lsm8 auto-vectorized impls and feature flags.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-Ctarget-cpu=native"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,63 @@
 version = 3
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "blake3"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "digest",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "crossbeam-channel"
@@ -59,10 +106,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -108,6 +186,7 @@ dependencies = [
 name = "oxidfract"
 version = "0.1.0"
 dependencies = [
+ "blake3",
  "rayon",
 ]
 
@@ -141,3 +220,21 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,14 @@ name = "oxidfract"
 path = "src/main.rs"
 
 [dependencies]
-rayon = "1.5"
+rayon = { version = "1.5", optional = true }
+blake3 = { version = "1.3", optional = true }
+
+[features]
+default = ["lsm8", "rayon", "blake3", "write_file"]
+
+write_file = []
+lsm = []
+lsm4 = []
+lsm8 = []
+lsm_avx2 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 #[allow(dead_code)]
 
 // maximum iteration count
-const MAX_ITER: i32 = 1000;
+pub const MAX_ITER: u32 = 1000;
 // escaoe radius squared
 const RADIUS_SQ: f64 = 4.0;
 
 // scalar implementation of Level Set Method
-pub fn lsm(cr: f64, ci: f64) -> i32 {
+pub fn lsm(cr: f64, ci: f64) -> u32 {
     // z (real and imaginary parts init)
     let mut zr = 0.0;
     let mut zi = 0.0;
@@ -29,48 +29,243 @@ pub fn lsm(cr: f64, ci: f64) -> i32 {
     iteration
 }
 
-#[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
-#[target_feature(enable = "avx2")]
-pub unsafe fn lsm_avx2(cr: __m256d, ci: __m256d) -> __m256d {
+// Auto vectorization x4 implementation of Level Set Method
+pub fn lsm4(cr: [f64; 4], ci: [f64; 4]) -> [u32; 4] {
     // z (real and imaginary parts init)
-    let mut zr = _mm256_set1_pd(0.0);
-    let mut zi = _mm256_set1_pd(0.0);
-
+    let mut zr = [0.0; 4];
+    let mut zi = [0.0; 4];
     // z^2 (real and imaginary parts init)
-    let mut zr2 = _mm256_set1_pd(0.0);
-    let mut zi2 = _mm256_set1_pd(0.0);
-
-    // useful constants
-    let one = _mm256_set1_pd(1.0);
-    let two = _mm256_set1_pd(2.0);
-    let four = _mm256_set1_pd(4.0);
-
-    // iteration counts
-    let mut iterations = _mm256_set1_pd(0.0);
+    let mut zr2 = [0.0; 4];
+    let mut zi2 = [0.0; 4];
+    // iteration count
+    let mut iteration = [0.0; 4];
 
     for _ in 0..MAX_ITER {
-        // comparison mask of the magnitudes with the escape radius
-        let mask = _mm256_cmp_pd::<_CMP_LT_OQ>(_mm256_add_pd(zr2, zi2), four);
-
-        // update the iteration counts
-        iterations = _mm256_add_pd(_mm256_and_pd(mask, one), iterations);
-
-        // break if all values exceeded the threshold
-        if _mm256_movemask_pd(mask) == 0 {
+        let mask = [
+            if zr2[0] + zi2[0] < RADIUS_SQ {
+                1.0
+            } else {
+                0.0
+            },
+            if zr2[1] + zi2[1] < RADIUS_SQ {
+                1.0
+            } else {
+                0.0
+            },
+            if zr2[2] + zi2[2] < RADIUS_SQ {
+                1.0
+            } else {
+                0.0
+            },
+            if zr2[3] + zi2[3] < RADIUS_SQ {
+                1.0
+            } else {
+                0.0
+            },
+        ];
+        if mask == [0.0; 4] {
             break;
         }
-
+        // and update the iteration count
+        iteration[0] = iteration[0] + mask[0];
+        iteration[1] = iteration[1] + mask[1];
+        iteration[2] = iteration[2] + mask[2];
+        iteration[3] = iteration[3] + mask[3];
         // update z
-        zi = _mm256_add_pd(_mm256_mul_pd(two, _mm256_mul_pd(zr, zi)), ci);
-        zr = _mm256_add_pd(_mm256_sub_pd(zr2, zi2), cr);
-
+        zi[0] = 2.0 * zr[0] * zi[0] + ci[0];
+        zi[1] = 2.0 * zr[1] * zi[1] + ci[1];
+        zi[2] = 2.0 * zr[2] * zi[2] + ci[2];
+        zi[3] = 2.0 * zr[3] * zi[3] + ci[3];
+        zr[0] = zr2[0] - zi2[0] + cr[0];
+        zr[1] = zr2[1] - zi2[1] + cr[1];
+        zr[2] = zr2[2] - zi2[2] + cr[2];
+        zr[3] = zr2[3] - zi2[3] + cr[3];
         // update z^2
-        zr2 = _mm256_mul_pd(zr, zr);
-        zi2 = _mm256_mul_pd(zi, zi);
+        zr2[0] = zr[0] * zr[0];
+        zr2[1] = zr[1] * zr[1];
+        zr2[2] = zr[2] * zr[2];
+        zr2[3] = zr[3] * zr[3];
+        zi2[0] = zi[0] * zi[0];
+        zi2[1] = zi[1] * zi[1];
+        zi2[2] = zi[2] * zi[2];
+        zi2[3] = zi[3] * zi[3];
     }
-    iterations
+    [
+        iteration[0] as u32,
+        iteration[1] as u32,
+        iteration[2] as u32,
+        iteration[3] as u32,
+    ]
 }
+
+// Auto vectorization x8 implementation of Level Set Method
+pub fn lsm8(cr: [f64; 8], ci: [f64; 8]) -> [u32; 8] {
+    // z (real and imaginary parts init)
+    let mut zr = [0.0; 8];
+    let mut zi = [0.0; 8];
+    // z^2 (real and imaginary parts init)
+    let mut zr2 = [0.0; 8];
+    let mut zi2 = [0.0; 8];
+    // iteration count
+    let mut iteration = [0.0; 8];
+
+    for _ in 0..MAX_ITER {
+        let mask = [
+            if zr2[0] + zi2[0] < RADIUS_SQ {
+                1.0
+            } else {
+                0.0
+            },
+            if zr2[1] + zi2[1] < RADIUS_SQ {
+                1.0
+            } else {
+                0.0
+            },
+            if zr2[2] + zi2[2] < RADIUS_SQ {
+                1.0
+            } else {
+                0.0
+            },
+            if zr2[3] + zi2[3] < RADIUS_SQ {
+                1.0
+            } else {
+                0.0
+            },
+            if zr2[4] + zi2[4] < RADIUS_SQ {
+                1.0
+            } else {
+                0.0
+            },
+            if zr2[5] + zi2[5] < RADIUS_SQ {
+                1.0
+            } else {
+                0.0
+            },
+            if zr2[6] + zi2[6] < RADIUS_SQ {
+                1.0
+            } else {
+                0.0
+            },
+            if zr2[7] + zi2[7] < RADIUS_SQ {
+                1.0
+            } else {
+                0.0
+            },
+        ];
+        if mask == [0.0; 8] {
+            break;
+        }
+        // and update the iteration count
+        iteration[0] = iteration[0] + mask[0];
+        iteration[1] = iteration[1] + mask[1];
+        iteration[2] = iteration[2] + mask[2];
+        iteration[3] = iteration[3] + mask[3];
+        iteration[4] = iteration[4] + mask[4];
+        iteration[5] = iteration[5] + mask[5];
+        iteration[6] = iteration[6] + mask[6];
+        iteration[7] = iteration[7] + mask[7];
+        // update z
+        zi[0] = 2.0 * zr[0] * zi[0] + ci[0];
+        zi[1] = 2.0 * zr[1] * zi[1] + ci[1];
+        zi[2] = 2.0 * zr[2] * zi[2] + ci[2];
+        zi[3] = 2.0 * zr[3] * zi[3] + ci[3];
+        zi[4] = 2.0 * zr[4] * zi[4] + ci[4];
+        zi[5] = 2.0 * zr[5] * zi[5] + ci[5];
+        zi[6] = 2.0 * zr[6] * zi[6] + ci[6];
+        zi[7] = 2.0 * zr[7] * zi[7] + ci[7];
+        zr[0] = zr2[0] - zi2[0] + cr[0];
+        zr[1] = zr2[1] - zi2[1] + cr[1];
+        zr[2] = zr2[2] - zi2[2] + cr[2];
+        zr[3] = zr2[3] - zi2[3] + cr[3];
+        zr[4] = zr2[4] - zi2[4] + cr[4];
+        zr[5] = zr2[5] - zi2[5] + cr[5];
+        zr[6] = zr2[6] - zi2[6] + cr[6];
+        zr[7] = zr2[7] - zi2[7] + cr[7];
+        // update z^2
+        zr2[0] = zr[0] * zr[0];
+        zr2[1] = zr[1] * zr[1];
+        zr2[2] = zr[2] * zr[2];
+        zr2[3] = zr[3] * zr[3];
+        zr2[4] = zr[4] * zr[4];
+        zr2[5] = zr[5] * zr[5];
+        zr2[6] = zr[6] * zr[6];
+        zr2[7] = zr[7] * zr[7];
+        zi2[0] = zi[0] * zi[0];
+        zi2[1] = zi[1] * zi[1];
+        zi2[2] = zi[2] * zi[2];
+        zi2[3] = zi[3] * zi[3];
+        zi2[4] = zi[4] * zi[4];
+        zi2[5] = zi[5] * zi[5];
+        zi2[6] = zi[6] * zi[6];
+        zi2[7] = zi[7] * zi[7];
+    }
+    [
+        iteration[0] as u32,
+        iteration[1] as u32,
+        iteration[2] as u32,
+        iteration[3] as u32,
+        iteration[4] as u32,
+        iteration[5] as u32,
+        iteration[6] as u32,
+        iteration[7] as u32,
+    ]
+}
+
+#[cfg(feature = "lsm_avx2")]
+mod avx2 {
+    use super::MAX_ITER;
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::*;
+    use std::mem::transmute;
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn lsm(cr: __m256d, ci: __m256d) -> __m256d {
+        // z (real and imaginary parts init)
+        let mut zr = _mm256_set1_pd(0.0);
+        let mut zi = _mm256_set1_pd(0.0);
+
+        // z^2 (real and imaginary parts init)
+        let mut zr2 = _mm256_set1_pd(0.0);
+        let mut zi2 = _mm256_set1_pd(0.0);
+
+        // useful constants
+        let one = _mm256_set1_pd(1.0);
+        let two = _mm256_set1_pd(2.0);
+        let four = _mm256_set1_pd(4.0);
+
+        // iteration counts
+        let mut iterations = _mm256_set1_pd(0.0);
+
+        for _ in 0..MAX_ITER {
+            // comparison mask of the magnitudes with the escape radius
+            let mask = _mm256_cmp_pd::<_CMP_LT_OQ>(_mm256_add_pd(zr2, zi2), four);
+
+            // break if all values exceeded the threshold
+            if _mm256_movemask_pd(mask) == 0 {
+                break;
+            }
+
+            // update the iteration counts
+            iterations = _mm256_add_pd(_mm256_and_pd(mask, one), iterations);
+
+            // update z
+            zi = _mm256_add_pd(_mm256_mul_pd(two, _mm256_mul_pd(zr, zi)), ci);
+            zr = _mm256_add_pd(_mm256_sub_pd(zr2, zi2), cr);
+
+            // update z^2
+            zr2 = _mm256_mul_pd(zr, zr);
+            zi2 = _mm256_mul_pd(zi, zi);
+        }
+        iterations
+    }
+
+    pub fn lsm_avx2(cr: [f64; 4], ci: [f64; 4]) -> [u32; 4] {
+        let f: [f64; 4] = unsafe { transmute(lsm(transmute(cr), transmute(ci))) };
+        [f[0] as u32, f[1] as u32, f[2] as u32, f[3] as u32]
+    }
+}
+#[cfg(feature = "lsm_avx2")]
+pub use avx2::lsm_avx2;
 
 #[cfg(test)]
 mod tests {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,20 @@
-use oxidfract::{lsm, lsm_avx2};
-use rayon::prelude::*;
-use std::fs::File;
-use std::io::prelude::*;
-use std::mem::transmute;
-use std::path::Path;
+#[cfg(feature = "lsm")]
+use oxidfract::lsm;
+#[cfg(feature = "lsm4")]
+use oxidfract::lsm4;
+#[cfg(feature = "lsm8")]
+use oxidfract::lsm8;
+#[cfg(feature = "lsm_avx2")]
+use oxidfract::lsm_avx2;
+use oxidfract::MAX_ITER;
 
-// maximum iteration count
-const MAX_ITER: i32 = 1000;
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
+
 // width of the frame
-const WIDTH: usize = 1280;
+const WIDTH: usize = 25600;
 // height of the frame
-const HEIGHT: usize = 720;
+const HEIGHT: usize = 25600;
 
 // mandelbrot range and domain
 const XMIN: f64 = -2.5;
@@ -18,83 +22,157 @@ const XMAX: f64 = 1.0;
 const YMIN: f64 = -1.0;
 const YMAX: f64 = 1.0;
 
+#[cfg(not(any(
+    feature = "lsm_avx2",
+    feature = "lsm",
+    feature = "lsm4",
+    feature = "lsm8"
+)))]
+compile_error!(
+    "at least one feature \"lsm_avx2\", \"lsm\" , \"lsm4\" or \"lsm8\" needs to be enabled"
+);
+
+#[cfg(feature = "lsm")]
 fn render_mandelbrot(palette: Vec<(u8, u8, u8)>) -> Vec<u8> {
     let mut img_buffer: Vec<u8> = vec![0; WIDTH * HEIGHT * 3];
 
-    // main loop through all the pixels
-    for y in 0..HEIGHT as u32 {
-        for x in 0..WIDTH as u32 {
-            // mapping the pixel coordinates to the Mandelbrot domain
-            let (cr, ci) = (
-                (x as f64 / WIDTH as f64) * (XMAX - XMIN) + XMIN,
-                (y as f64 / HEIGHT as f64) * (YMAX - YMIN) + YMIN,
-            );
+    #[cfg(feature = "rayon")]
+    let buf_iter = img_buffer.par_chunks_exact_mut(WIDTH * 3);
+    #[cfg(not(feature = "rayon"))]
+    let buf_iter = img_buffer.chunks_exact_mut(WIDTH * 3);
+
+    buf_iter.enumerate().for_each(|(y, rows)| {
+        let ci = (y as f64 / HEIGHT as f64) * (YMAX - YMIN) + YMIN;
+
+        rows.chunks_exact_mut(3).enumerate().for_each(|(x, pixel)| {
+            let cr = (x as f64 / WIDTH as f64) * (XMAX - XMIN) + XMIN;
             // calculate iterations
             let iterations = lsm(cr, ci);
-
-            // set the pixels according to the iterations count
-            let pixel_r = (y as usize * WIDTH + x as usize) * 3;
-            let pixel_g = (y as usize * WIDTH + x as usize) * 3 + 1;
-            let pixel_b = (y as usize * WIDTH + x as usize) * 3 + 2;
-
             if iterations == MAX_ITER {
-                img_buffer[pixel_r] = 0;
-                img_buffer[pixel_g] = 0;
-                img_buffer[pixel_b] = 0;
+                pixel[0] = 0;
+                pixel[1] = 0;
+                pixel[2] = 0;
             } else {
-                img_buffer[pixel_r] = palette[iterations as usize % palette.len()].0;
-                img_buffer[pixel_g] = palette[iterations as usize % palette.len()].1;
-                img_buffer[pixel_b] = palette[iterations as usize % palette.len()].2;
+                pixel[0] = palette[iterations as usize % palette.len()].0;
+                pixel[1] = palette[iterations as usize % palette.len()].1;
+                pixel[2] = palette[iterations as usize % palette.len()].2;
             }
-        }
-    }
+        });
+    });
+
     img_buffer
 }
 
-fn render_parallel_mandelbrot(palette: Vec<(u8, u8, u8)>) -> Vec<u8> {
+#[cfg(feature = "lsm8")]
+fn render_mandelbrot(palette: Vec<(u8, u8, u8)>) -> Vec<u8> {
     let mut img_buffer: Vec<u8> = vec![0; WIDTH * HEIGHT * 3];
 
-    img_buffer
-        .par_chunks_exact_mut(WIDTH * 3)
-        .enumerate()
-        .for_each(|(y, rows)| {
-            rows.chunks_exact_mut(12)
-                .enumerate()
-                .for_each(|(c, chunk)| {
-                    let c = (c as f64) * 4.0;
-                    let y = y as f64;
+    #[cfg(feature = "rayon")]
+    let buf_iter = img_buffer.par_chunks_exact_mut(WIDTH * 3);
+    #[cfg(not(feature = "rayon"))]
+    let buf_iter = img_buffer.chunks_exact_mut(WIDTH * 3);
 
-                    let cr = &mut [c, c + 1.0, c + 2.0, c + 3.0];
-                    let ci = &mut [y; 4];
+    buf_iter.enumerate().for_each(|(y, rows)| {
+        let ci = (y as f64 / HEIGHT as f64) * (YMAX - YMIN) + YMIN;
+        let ci = &mut [ci; 8];
 
-                    for (cr, ci) in cr.iter_mut().zip(ci.iter_mut()) {
-                        *cr = (*cr / WIDTH as f64) * (XMAX - XMIN) + XMIN;
-                        *ci = (*ci / HEIGHT as f64) * (YMAX - YMIN) + YMIN;
-                    }
+        rows.chunks_exact_mut(8 * 3)
+            .enumerate()
+            .for_each(|(c, chunk)| {
+                let c = (c as f64) * 8.0;
 
-                    let iterations: [f64; 4] =
-                        unsafe { transmute(lsm_avx2(transmute(*cr), transmute(*ci))) };
-                    chunk
-                        .chunks_exact_mut(3)
-                        .enumerate()
-                        .for_each(|(t, triplet)| {
-                            if iterations[t] == MAX_ITER as f64 {
-                                triplet[0] = 0;
-                                triplet[1] = 0;
-                                triplet[2] = 0;
-                            } else {
-                                triplet[0] = palette[iterations[t] as usize % palette.len()].0;
-                                triplet[1] = palette[iterations[t] as usize % palette.len()].1;
-                                triplet[2] = palette[iterations[t] as usize % palette.len()].2;
-                            }
-                        })
-                });
-        });
+                let cr = &mut [
+                    c,
+                    c + 1.0,
+                    c + 2.0,
+                    c + 3.0,
+                    c + 4.0,
+                    c + 5.0,
+                    c + 6.0,
+                    c + 7.0,
+                ];
+
+                for cr in cr.iter_mut() {
+                    *cr = (*cr / WIDTH as f64) * (XMAX - XMIN) + XMIN;
+                }
+
+                let iterations: [u32; 8] = lsm8(*cr, *ci);
+
+                chunk
+                    .chunks_exact_mut(3)
+                    .enumerate()
+                    .for_each(|(t, triplet)| {
+                        if iterations[t] == MAX_ITER {
+                            triplet[0] = 0;
+                            triplet[1] = 0;
+                            triplet[2] = 0;
+                        } else {
+                            triplet[0] = palette[iterations[t] as usize % palette.len()].0;
+                            triplet[1] = palette[iterations[t] as usize % palette.len()].1;
+                            triplet[2] = palette[iterations[t] as usize % palette.len()].2;
+                        }
+                    })
+            });
+    });
 
     img_buffer
 }
 
+#[cfg(any(feature = "lsm_avx2", feature = "lsm4"))]
+fn render_mandelbrot(palette: Vec<(u8, u8, u8)>) -> Vec<u8> {
+    let mut img_buffer: Vec<u8> = vec![0; WIDTH * HEIGHT * 3];
+
+    #[cfg(feature = "rayon")]
+    let buf_iter = img_buffer.par_chunks_exact_mut(WIDTH * 3);
+    #[cfg(not(feature = "rayon"))]
+    let buf_iter = img_buffer.chunks_exact_mut(WIDTH * 3);
+
+    buf_iter.enumerate().for_each(|(y, rows)| {
+        let ci = (y as f64 / HEIGHT as f64) * (YMAX - YMIN) + YMIN;
+        let ci = &mut [ci; 4];
+
+        rows.chunks_exact_mut(12)
+            .enumerate()
+            .for_each(|(c, chunk)| {
+                let c = (c as f64) * 4.0;
+
+                let cr = &mut [c, c + 1.0, c + 2.0, c + 3.0];
+
+                for cr in cr.iter_mut() {
+                    *cr = (*cr / WIDTH as f64) * (XMAX - XMIN) + XMIN;
+                }
+
+                #[cfg(feature = "lsm4")]
+                let iterations: [u32; 4] = lsm4(*cr, *ci);
+                #[cfg(feature = "lsm_avx2")]
+                let iterations: [u32; 4] = lsm_avx2(*cr, *ci);
+
+                chunk
+                    .chunks_exact_mut(3)
+                    .enumerate()
+                    .for_each(|(t, triplet)| {
+                        if iterations[t] == MAX_ITER {
+                            triplet[0] = 0;
+                            triplet[1] = 0;
+                            triplet[2] = 0;
+                        } else {
+                            triplet[0] = palette[iterations[t] as usize % palette.len()].0;
+                            triplet[1] = palette[iterations[t] as usize % palette.len()].1;
+                            triplet[2] = palette[iterations[t] as usize % palette.len()].2;
+                        }
+                    })
+            });
+    });
+
+    img_buffer
+}
+
+#[cfg(feature = "write_file")]
 fn write_file(data: Vec<u8>, filename: &str) -> std::io::Result<()> {
+    use std::fs::File;
+    use std::io::prelude::*;
+    use std::path::Path;
+
     let path = Path::new(filename);
     let mut file = File::create(&path)?;
     let header = format!("P6 {} {} 255\n", WIDTH, HEIGHT);
@@ -110,6 +188,16 @@ fn main() -> Result<(), std::io::Error> {
         (244, 162, 97),
         (231, 111, 81),
     ];
-    let fractal = render_parallel_mandelbrot(palette);
-    write_file(fractal, "out/fractal.ppm")
+    let fractal = render_mandelbrot(palette);
+
+    #[cfg(feature = "blake3")]
+    {
+        let hash = blake3::hash(&fractal);
+        println!("hash = {hash:?}");
+    }
+
+    #[cfg(feature = "write_file")]
+    write_file(fractal, "out/fractal.ppm")?;
+
+    Ok(())
 }


### PR DESCRIPTION
I saw your post on HackerNews and wanted to see if the Rust compiler could auto-vectorize the `lsm` code with avx2.  This PR adds two implementations that the compiler can auto-vectorize (even uses avx2 when compiled with `RUSTFLAGS="-C target-cpu=native"`, see the `.cargo/config.toml` file).

By passing in fixed-length arrays to the `lsm4` function, the compiler can work out the common operators and produce basically the same avx2 code as the original avx2 implementation.  The compiler also unrolls the outer `MAX_ITER` loop, giving the `lsm4` a small increase in performance.  The `lsm8` impl. works on 8 inputs instead of 4 at a time and is almost x2 faster then `lsm4`.